### PR TITLE
custom network stdout fix

### DIFF
--- a/snap-guest
+++ b/snap-guest
@@ -211,7 +211,7 @@ virt-install --vcpus $CPUS \
 if [ $ADD_IP -eq 1 ]; then
   echo "Waiting for IP"
   i=0
-  until [ $i -ge 100 ] || IP_LINE=`cat /var/lib/libvirt/dnsmasq/default.leases /var/lib/dnsmasq/dnsmasq.leases 2>/dev/null | grep "$MAC"`; do
+  until [ $i -ge 100 ] || IP_LINE=`cat /var/lib/libvirt/dnsmasq/${NETWORK/network=}.leases /var/lib/dnsmasq/dnsmasq.leases 2>/dev/null | grep "$MAC"`; do
     i=$((i + 1))
     sleep 1
   done


### PR DESCRIPTION
When creating new guest with other then default network, no or wrong IP address is put on stdout during guest creating, because script is looking for the IP only in the default.leases file.

Fixed so appropriate file is taken for the IP address.
